### PR TITLE
sync gitignore with sapper-template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
-node_modules
+/node_modules/
+/src/node_modules/@sapper/
 yarn-error.log
 /cypress/screenshots/
 /__sapper__/


### PR DESCRIPTION
The sapper template now promotes using the `src/node_modules/` folder to store `components/` etc so they can be imported without the need for directory changing (eg `../components/Nav.svelte`) but using the node resolution instead of a rollup/webpack plugin